### PR TITLE
optimize iterations of BedrockMappingData

### DIFF
--- a/src/main/java/net/raphimc/viabedrock/protocol/data/BedrockMappingData.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/data/BedrockMappingData.java
@@ -379,6 +379,11 @@ public class BedrockMappingData extends MappingDataBase {
             final JsonObject bedrockToJavaItemMappingsJson = this.readJson("custom/item_mappings.json");
             this.bedrockToJavaBlockItems = new HashMap<>(bedrockToJavaItemMappingsJson.size());
             this.bedrockToJavaMetaItems = new HashMap<>(bedrockToJavaItemMappingsJson.size());
+            // NamespacedIdentifier to BedrockBlockState
+            final Map<String, BedrockBlockState> bedrockBlockStateTable = new HashMap<>(this.bedrockBlockStates.size(), 1.0F);
+            for (final BedrockBlockState bedrockBlockState : this.bedrockBlockStates) {
+                bedrockBlockStateTable.put(bedrockBlockState.namespacedIdentifier(), bedrockBlockState);
+            }
             for (Map.Entry<String, JsonElement> entry : bedrockToJavaItemMappingsJson.entrySet()) {
                 final String bedrockIdentifier = entry.getKey();
                 if (!this.bedrockItems.containsKey(bedrockIdentifier)) {
@@ -397,16 +402,15 @@ public class BedrockMappingData extends MappingDataBase {
                         final BlockState blockState = BlockState.fromString(blockMapping.getKey());
                         final String blockStateIdentifier = blockState.namespacedIdentifier();
                         final List<BlockState> blockStates = new ArrayList<>();
-                        for (BedrockBlockState bedrockBlockState : this.bedrockBlockStates) {
-                            if (bedrockBlockState.namespacedIdentifier().equals(blockStateIdentifier)) {
-                                if (!bedrockBlockState.properties().keySet().containsAll(blockState.properties().keySet())) {
-                                    throw new RuntimeException("Unknown bedrock block state property: " + blockState.properties().keySet() + " for " + blockStateIdentifier);
-                                }
-                                if (bedrockBlockState.properties().entrySet().containsAll(blockState.properties().entrySet())) {
-                                    blockStates.add(bedrockBlockState);
-                                }
-                                allPossibleStates.add(bedrockBlockState);
+                        final BedrockBlockState bedrockBlockState = bedrockBlockStateTable.get(blockStateIdentifier);
+                        if (bedrockBlockState != null) {
+                            if (!bedrockBlockState.properties().keySet().containsAll(blockState.properties().keySet())) {
+                                throw new RuntimeException("Unknown bedrock block state property: " + blockState.properties().keySet() + " for " + blockStateIdentifier);
                             }
+                            if (bedrockBlockState.properties().entrySet().containsAll(blockState.properties().entrySet())) {
+                                blockStates.add(bedrockBlockState);
+                            }
+                            allPossibleStates.add(bedrockBlockState);
                         }
                         if (blockStates.isEmpty()) {
                             throw new RuntimeException("Unknown bedrock block state: " + blockState.toBlockStateString());


### PR DESCRIPTION
In my tests, the `namespacedIdentifier` invocation consumes more than 1GiB for String objects (`byte[]`) and about 2.5 seconds here on client launching. This table will only invoke this method for all block states once.