### PR TITLE
Implement item use and item release translation.

### DIFF
--- a/src/main/java/net/raphimc/viabedrock/experimental/ExperimentalFeatures.java
+++ b/src/main/java/net/raphimc/viabedrock/experimental/ExperimentalFeatures.java
@@ -52,8 +52,10 @@ public class ExperimentalFeatures {
                 return;
             }
 
+
             final InventoryContainer inventoryContainer = wrapper.user().get(InventoryTracker.class).getInventoryContainer();
 
+            wrapper.clearPacket();
             wrapper.setPacketType(ServerboundBedrockPackets.INVENTORY_TRANSACTION);
 
             wrapper.write(BedrockTypes.VAR_INT, 0); // legacy request id


### PR DESCRIPTION
- Both server-authoritative inventory and client-authoritative inventory send this packet for item usage and release.
- As of 1.21.90 or whatever I implement this on, when the item changed (eg: throwing potions), the client don't send any actions to tell the server that the item has changed, unlike block interaction where the client actually tell the server what changed. So this implementation is correct.

What's missing:
- Let the server know when we want to start using item (slowdown) through the START_USING_ITEM auth input.
- As [Exterminate5573](https://github.com/Exterminate5573) mentioned, off hand item usage should be handle better to prevent desync.

NOTE: THIS ONLY IMPLEMENT NON-BLOCK-INTERACTION ITEM USE, WHICH MEANS THAT BLOCK PLACING WILL NOT WORKS.