### PR TITLE
Use Types#CUSTOM_CLICK_ACTION_TAG for reading payload

### DIFF
--- a/src/main/java/net/raphimc/viabedrock/protocol/packet/InventoryPackets.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/packet/InventoryPackets.java
@@ -402,7 +402,7 @@ public class InventoryPackets {
         });
         protocol.registerServerbound(ServerboundPackets1_21_6.CUSTOM_CLICK_ACTION, ServerboundBedrockPackets.MODAL_FORM_RESPONSE, wrapper -> {
             final String id = wrapper.read(Types.STRING); // id
-            final CompoundTag payload = (CompoundTag) wrapper.read(Types.OPTIONAL_TAG); // payload
+            final CompoundTag payload = (CompoundTag) wrapper.read(Types.CUSTOM_CLICK_ACTION_TAG); // payload
             final InventoryTracker inventoryTracker = wrapper.user().get(InventoryTracker.class);
             if (inventoryTracker.getCurrentForm() == null) {
                 wrapper.cancel();


### PR DESCRIPTION
No one noticed this was wrong as optional tag read the length away using readBoolean(), but Minecraft length prefixes the tag and uses the length as optional indicator.