### PR TITLE
Fix: wrap yaw rotation to 180/-180 to match Bedrock behaviour.

### DIFF
--- a/src/main/java/net/raphimc/viabedrock/api/util/MathUtil.java
+++ b/src/main/java/net/raphimc/viabedrock/api/util/MathUtil.java
@@ -36,6 +36,16 @@ public class MathUtil {
         return f < i ? i - 1 : i;
     }
 
+    public static float wrapDegrees(float degrees) {
+        degrees = degrees % 360.0f;
+        if (degrees < -180.0f) {
+            degrees += 360.0f;
+        } else if (degrees >= 180.0f) {
+            degrees -= 360.0f;
+        }
+        return degrees;
+    }
+
     public static float clamp(final float value, final float min, final float max) {
         if (value < min) {
             return min;

--- a/src/main/java/net/raphimc/viabedrock/protocol/packet/ClientPlayerPackets.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/packet/ClientPlayerPackets.java
@@ -413,12 +413,12 @@ public class ClientPlayerPackets {
         protocol.registerServerbound(ServerboundPackets1_21_6.MOVE_PLAYER_POS_ROT, null, wrapper -> {
             wrapper.cancel();
             final ClientPlayerEntity clientPlayer = wrapper.user().get(EntityTracker.class).getClientPlayer();
-            clientPlayer.updatePlayerPosition(wrapper.read(Types.DOUBLE), wrapper.read(Types.DOUBLE), wrapper.read(Types.DOUBLE), wrapper.read(Types.FLOAT), wrapper.read(Types.FLOAT), wrapper.read(Types.UNSIGNED_BYTE));
+            clientPlayer.updatePlayerPosition(wrapper.read(Types.DOUBLE), wrapper.read(Types.DOUBLE), wrapper.read(Types.DOUBLE), MathUtil.wrapDegrees(wrapper.read(Types.FLOAT)), wrapper.read(Types.FLOAT), wrapper.read(Types.UNSIGNED_BYTE));
         });
         protocol.registerServerbound(ServerboundPackets1_21_6.MOVE_PLAYER_ROT, null, wrapper -> {
             wrapper.cancel();
             final ClientPlayerEntity clientPlayer = wrapper.user().get(EntityTracker.class).getClientPlayer();
-            clientPlayer.updatePlayerPosition(wrapper.read(Types.FLOAT), wrapper.read(Types.FLOAT), wrapper.read(Types.UNSIGNED_BYTE));
+            clientPlayer.updatePlayerPosition(MathUtil.wrapDegrees(wrapper.read(Types.FLOAT)), wrapper.read(Types.FLOAT), wrapper.read(Types.UNSIGNED_BYTE));
         });
         protocol.registerServerbound(ServerboundPackets1_21_6.ACCEPT_TELEPORTATION, null, wrapper -> {
             wrapper.cancel();


### PR DESCRIPTION
Does what it said, this is vanilla behaviour on Bedrock, you can't rotate beyond the -180/180 value.