### PR TITLE
Fix: broken custom entites/model & update CubeConverter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     api "com.vdurmont:semver4j:3.1.0"
     api "com.mojang:brigadier:1.3.10"
     api "at.yawk.lz4:lz4-java:1.11.0"
-    api("com.github.oryxel1:CubeConverter:5b4fce77c4") {
+    api("com.github.oryxel1:CubeConverter:4117f10057") {
         transitive = false
     }
     api("team.unnamed:mocha:3.0.1") {

--- a/src/main/java/net/raphimc/viabedrock/api/model/entity/CustomEntity.java
+++ b/src/main/java/net/raphimc/viabedrock/api/model/entity/CustomEntity.java
@@ -30,6 +30,7 @@ import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Types;
 import com.viaversion.viaversion.api.type.types.version.VersionedTypes;
 import com.viaversion.viaversion.protocols.v1_21_11to26_1.packet.ClientboundPackets26_1;
+import com.viaversion.viaversion.util.Key;
 import net.raphimc.viabedrock.ViaBedrock;
 import net.raphimc.viabedrock.api.modinterface.ViaBedrockUtilityInterface;
 import net.raphimc.viabedrock.api.resourcepack.definition.EntityDefinitions;
@@ -175,7 +176,7 @@ public class CustomEntity extends Entity {
             final List<EntityData> javaEntityData = new ArrayList<>();
 
             final StructuredDataContainer data = ProtocolConstants.createStructuredDataContainer();
-            data.set(StructuredDataKey.ITEM_MODEL, new ItemModel(CustomEntityResourceRewriter.ITEM_MODEL_KEY));
+            data.set(StructuredDataKey.ITEM_MODEL, new ItemModel(Key.of("viabedrock", String.valueOf(key.hashCode()))));
             data.set(StructuredDataKey.CUSTOM_MODEL_DATA1_21_4, CustomEntityResourceRewriter.getCustomModelData(key));
             final StructuredItem item = new StructuredItem(BedrockProtocol.MAPPINGS.getJavaItems().get("minecraft:paper"), 1, data);
             javaEntityData.add(new EntityData(partEntity.getJavaEntityDataIndex(EntityDataFields.ITEM_STACK), VersionedTypes.V26_1.entityDataTypes.itemType, item));

--- a/src/main/java/net/raphimc/viabedrock/api/resourcepack/http/ResourcePackHttpServer.java
+++ b/src/main/java/net/raphimc/viabedrock/api/resourcepack/http/ResourcePackHttpServer.java
@@ -91,8 +91,6 @@ public class ResourcePackHttpServer {
                                         final long end = System.nanoTime();
                                         ViaBedrock.getPlatform().getLogger().log(Level.INFO, "Converted resource packs in " + ((end - start) / 1_000_000L) + "ms");
 
-                                        Files.write(new File("test.zip").toPath(), data);
-
                                         final DefaultHttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
                                         response.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
                                         response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/octet-stream");

--- a/src/main/java/net/raphimc/viabedrock/api/resourcepack/http/ResourcePackHttpServer.java
+++ b/src/main/java/net/raphimc/viabedrock/api/resourcepack/http/ResourcePackHttpServer.java
@@ -31,7 +31,9 @@ import net.raphimc.viabedrock.protocol.rewriter.ResourcePackRewriter;
 import net.raphimc.viabedrock.protocol.storage.ResourcePackStorage;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -88,6 +90,8 @@ public class ResourcePackHttpServer {
                                         final byte[] data = javaContent.toZip();
                                         final long end = System.nanoTime();
                                         ViaBedrock.getPlatform().getLogger().log(Level.INFO, "Converted resource packs in " + ((end - start) / 1_000_000L) + "ms");
+
+                                        Files.write(new File("test.zip").toPath(), data);
 
                                         final DefaultHttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
                                         response.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);

--- a/src/main/java/net/raphimc/viabedrock/protocol/rewriter/ItemRewriter.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/rewriter/ItemRewriter.java
@@ -194,10 +194,10 @@ public class ItemRewriter extends StoredObject {
                 }
 
                 if (resourcePackStorage.getAttachables().attachables().containsKey(identifier) && resourcePackStorage.isLoadedOnJavaClient() && resourcePackStorage.getConverterData().containsKey("ca_" + identifier + "_default")) {
-                    data.set(StructuredDataKey.ITEM_MODEL, new ItemModel(CustomAttachableResourceRewriter.ITEM_MODEL_KEY));
+                    data.set(StructuredDataKey.ITEM_MODEL, new ItemModel(Key.of("viabedrock", String.valueOf((identifier + "_default").hashCode()))));
                     data.set(StructuredDataKey.CUSTOM_MODEL_DATA1_21_4, CustomAttachableResourceRewriter.getCustomModelData(identifier + "_default"));
                 } else if (itemDefinition.iconComponent() != null && resourcePackStorage.isLoadedOnJavaClient()) {
-                    data.set(StructuredDataKey.ITEM_MODEL, new ItemModel(CustomItemTextureResourceRewriter.ITEM_MODEL_KEY));
+                    data.set(StructuredDataKey.ITEM_MODEL, new ItemModel(Key.of("viabedrock", String.valueOf((itemDefinition.iconComponent() + "_0").hashCode()))));
                     data.set(StructuredDataKey.CUSTOM_MODEL_DATA1_21_4, CustomItemTextureResourceRewriter.getCustomModelData(itemDefinition.iconComponent() + "_0"));
                 } else {
                     data.set(StructuredDataKey.LORE, new Tag[]{TextUtil.stringToNbt("§7[ViaBedrock] Custom item: " + identifier)});

--- a/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomAttachableResourceRewriter.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomAttachableResourceRewriter.java
@@ -58,7 +58,7 @@ public class CustomAttachableResourceRewriter extends ItemModelResourceRewriter 
                 if (!attachableDefinition.attachableData().getTextures().containsKey(modelEntry.getKey())) continue;
 
                 final String javaTexturePath = this.getJavaTexturePath(attachableDefinition.attachableData().getTextures().get(modelEntry.getKey()));
-                final JavaItemModel itemModelData = bedrockGeometry.toJavaItemModel("viabedrock:" + javaTexturePath, RotationType.POST_1_21_6);
+                final JavaItemModel itemModelData = bedrockGeometry.toJavaItemModel("viabedrock:" + javaTexturePath, RotationType.POST_1_21_11);
                 final JsonObject itemModel = GsonUtil.getGson().fromJson(itemModelData.compile().toString(), JsonObject.class);
 
                 final JsonObject display = new JsonObject();

--- a/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomAttachableResourceRewriter.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomAttachableResourceRewriter.java
@@ -33,11 +33,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class CustomAttachableResourceRewriter extends ItemModelResourceRewriter {
-
-    public static final Key ITEM_MODEL_KEY = Key.of("viabedrock", "attachable");
-
     public CustomAttachableResourceRewriter() {
-        super("attachable", "attachable");
+        super("attachable");
     }
 
     @Override

--- a/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomEntityResourceRewriter.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomEntityResourceRewriter.java
@@ -56,7 +56,7 @@ public class CustomEntityResourceRewriter extends ItemModelResourceRewriter {
                 for (Map.Entry<String, String> textureEntry : entityDefinition.entityData().getTextures().entrySet()) {
                     final String javaTexturePath = this.getJavaTexturePath(textureEntry.getValue());
                     final String key = entityEntry.getKey() + "_" + modelEntry.getKey() + "_" + textureEntry.getKey();
-                    final JavaItemModel itemModelData = bedrockGeometry.toJavaItemModel("viabedrock:" + javaTexturePath, RotationType.HACKY_POST_1_21_6);
+                    final JavaItemModel itemModelData = bedrockGeometry.toJavaItemModel("viabedrock:" + javaTexturePath, RotationType.POST_1_21_11);
                     resourcePackStorage.getConverterData().put("ce_" + key + "_scale", itemModelData.getScale());
                     javaContent.putString("assets/viabedrock/models/" + this.getJavaModelName(key) + ".json", itemModelData.compile().toString());
                     modelsList.add(key);

--- a/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomEntityResourceRewriter.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomEntityResourceRewriter.java
@@ -30,11 +30,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class CustomEntityResourceRewriter extends ItemModelResourceRewriter {
-
-    public static final Key ITEM_MODEL_KEY = Key.of("viabedrock", "entity");
-
     public CustomEntityResourceRewriter() {
-        super("entity", "entity");
+        super("entity");
     }
 
     @Override

--- a/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomItemTextureResourceRewriter.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/CustomItemTextureResourceRewriter.java
@@ -29,11 +29,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class CustomItemTextureResourceRewriter extends ItemModelResourceRewriter {
-
-    public static final Key ITEM_MODEL_KEY = Key.of("viabedrock", "item_texture");
-
     public CustomItemTextureResourceRewriter() {
-        super("item_texture", "item");
+        super("item");
     }
 
     @Override

--- a/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/ItemModelResourceRewriter.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/rewriter/resourcepack/ItemModelResourceRewriter.java
@@ -34,11 +34,9 @@ public abstract class ItemModelResourceRewriter implements ResourcePackRewriter.
         return new CustomModelData1_21_4(new float[0], new boolean[0], new String[]{key}, new int[0]);
     }
 
-    private final String name;
     private final String subFolder;
 
-    public ItemModelResourceRewriter(final String name, final String subFolder) {
-        this.name = name;
+    public ItemModelResourceRewriter(final String subFolder) {
         this.subFolder = subFolder;
     }
 
@@ -46,27 +44,30 @@ public abstract class ItemModelResourceRewriter implements ResourcePackRewriter.
     public final void apply(final ResourcePackStorage resourcePackStorage, final Content javaContent) {
         final Set<String> modelsList = new HashSet<>();
         this.apply(resourcePackStorage, javaContent, modelsList);
-        if (!modelsList.isEmpty()) {
+        if (modelsList.isEmpty()) {
+            return;
+        }
+
+        for (String modelKey : modelsList) {
             final JsonArray cases = new JsonArray();
-            for (String modelKey : modelsList) {
-                final JsonObject caseObj = new JsonObject();
-                caseObj.addProperty("when", modelKey);
+            final JsonObject caseObj = new JsonObject();
+            caseObj.addProperty("when", modelKey);
 
-                final JsonObject model = new JsonObject();
-                model.addProperty("type", "minecraft:model");
-                model.addProperty("model", "viabedrock:" + this.getJavaModelName(modelKey));
-                caseObj.add("model", model);
+            final JsonObject model = new JsonObject();
+            model.addProperty("type", "minecraft:model");
+            model.addProperty("model", "viabedrock:" + this.getJavaModelName(modelKey));
+            caseObj.add("model", model);
 
-                cases.add(caseObj);
-            }
+            cases.add(caseObj);
+
+            final JsonObject model1 = new JsonObject();
+            model1.addProperty("type", "minecraft:select");
+            model1.addProperty("property", "minecraft:custom_model_data");
+            model1.add("cases", cases);
 
             final JsonObject itemDefinition = new JsonObject();
-            final JsonObject model = new JsonObject();
-            model.addProperty("type", "minecraft:select");
-            model.addProperty("property", "minecraft:custom_model_data");
-            model.add("cases", cases);
             itemDefinition.add("model", model);
-            javaContent.putJson("assets/viabedrock/items/" + this.name + ".json", itemDefinition);
+            javaContent.putJson("assets/viabedrock/items/" + modelKey.hashCode() + ".json", itemDefinition);
         }
     }
 
@@ -79,5 +80,4 @@ public abstract class ItemModelResourceRewriter implements ResourcePackRewriter.
     protected String getJavaTexturePath(final String bedrockPath) {
         return "item/" + this.subFolder + '/' + StringUtil.makeIdentifierValueSafe(bedrockPath.replace("textures/", ""));
     }
-
 }


### PR DESCRIPTION
does what it said, minecraft dislike having too many models in one file so this PR just split it.