### PR TITLE
Stabilize entity metadata and entity mounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ hs_err_pid*
 build/
 out/
 /run/
+/.memoirs/

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Here is an overview of the current and planned features in ViaBedrock.
 - [x] Player spawning
 - [x] Entity spawning
 - [x] Entity interactions
-- [ ] Entity metadata
+- [x] Entity metadata
 - [x] Entity attributes
-- [ ] Entity mounting
+- [x] Entity mounting
 - [x] Player abilities
 - [x] Movement
 - [ ] Client-Authoritative Inventory
@@ -58,7 +58,6 @@ Some features are experimental, which means they are almost certainly not fully 
 
 * Block placing
 * Item use
-* Entity metadata
 * Some item data
 
 ## Optional clientside mods

--- a/src/main/java/net/raphimc/viabedrock/api/model/entity/ClientPlayerEntity.java
+++ b/src/main/java/net/raphimc/viabedrock/api/model/entity/ClientPlayerEntity.java
@@ -27,7 +27,6 @@ import com.viaversion.viaversion.util.Pair;
 import net.raphimc.viabedrock.ViaBedrock;
 import net.raphimc.viabedrock.api.util.EnumUtil;
 import net.raphimc.viabedrock.api.util.PacketFactory;
-import net.raphimc.viabedrock.experimental.ExperimentalPacketFactory;
 import net.raphimc.viabedrock.protocol.BedrockProtocol;
 import net.raphimc.viabedrock.protocol.ServerboundBedrockPackets;
 import net.raphimc.viabedrock.protocol.data.enums.Direction;
@@ -104,14 +103,10 @@ public class ClientPlayerEntity extends PlayerEntity {
         this.prevOnGround = this.onGround;
         this.prevInputFlags = this.inputFlags;
 
-        if (ViaBedrock.getConfig().shouldEnableExperimentalFeatures()) {
-            // TODO: Experimental
-
-            if (this.mountRuntimeId != -1 && this.sneaking && !this.requestedDismount) {
-                // Dismount entity
-                ExperimentalPacketFactory.sendBedrockDismount(this.user, this.mountRuntimeId);
-                this.requestedDismount = true;
-            }
+        if (this.mountRuntimeId != -1 && this.sneaking && !this.requestedDismount) {
+            // Dismount entity
+            PacketFactory.sendBedrockDismount(this.user, this.mountRuntimeId, this.position);
+            this.requestedDismount = true;
         }
     }
 

--- a/src/main/java/net/raphimc/viabedrock/api/model/entity/Entity.java
+++ b/src/main/java/net/raphimc/viabedrock/api/model/entity/Entity.java
@@ -26,7 +26,6 @@ import com.viaversion.viaversion.api.type.types.version.VersionedTypes;
 import com.viaversion.viaversion.protocols.v1_21_11to26_1.packet.ClientboundPackets26_1;
 import net.raphimc.viabedrock.ViaBedrock;
 import net.raphimc.viabedrock.api.util.EnumUtil;
-import net.raphimc.viabedrock.experimental.rewriter.EntityMetadataRewriter;
 import net.raphimc.viabedrock.protocol.BedrockProtocol;
 import net.raphimc.viabedrock.protocol.ClientboundBedrockPackets;
 import net.raphimc.viabedrock.protocol.data.enums.bedrock.ActorDataIDs;
@@ -34,6 +33,8 @@ import net.raphimc.viabedrock.protocol.data.enums.bedrock.ActorFlags;
 import net.raphimc.viabedrock.protocol.data.enums.bedrock.generated.DataItemType;
 import net.raphimc.viabedrock.protocol.data.enums.java.generated.BossEventOperationType;
 import net.raphimc.viabedrock.protocol.model.Position3f;
+import net.raphimc.viabedrock.protocol.rewriter.EntityMetadataRewriter;
+import net.raphimc.viabedrock.protocol.storage.EntityTracker;
 import net.raphimc.viabedrock.protocol.types.BedrockTypes;
 import net.raphimc.viabedrock.protocol.types.entitydata.EntityDataTypesBedrock;
 
@@ -65,7 +66,7 @@ public class Entity {
     protected int age;
     protected boolean hasBossBar;
 
-    // Mounting
+    // Mounting. Note: the passengers list stores Bedrock entity unique IDs, not runtime IDs
     protected List<Long> passengers = new ArrayList<>();
     protected long mountRuntimeId = -1;
 
@@ -116,8 +117,7 @@ public class Entity {
             }
             this.entityData.put(dataId, data);
             if (!this.translateEntityData(dataId, data, javaEntityData)) {
-                // TODO: Log warning when entity data translation is fully implemented
-                // ViaBedrock.getPlatform().getLogger().log(Level.WARNING, "Received unknown entity data: " + dataId + " for entity type: " + this.type);
+                ViaBedrock.getPlatform().getLogger().log(Level.FINE, "Received unsupported entity data: " + dataId + " for entity type: " + this.type);
             }
         }
         this.onEntityDataChanged();
@@ -223,14 +223,25 @@ public class Entity {
         this.hasBossBar = hasBossBar;
     }
 
-    public void addPassenger(final long passengerRuntimeId) {
-        if (!this.passengers.contains(passengerRuntimeId)) {
-            this.passengers.add(passengerRuntimeId);
+    public void addPassenger(final long passengerUniqueId) {
+        if (!this.passengers.contains(passengerUniqueId)) {
+            this.passengers.add(passengerUniqueId);
         }
     }
 
-    public void removePassenger(final long passengerRuntimeId) {
-        this.passengers.remove(passengerRuntimeId);
+    public void addRider(final long passengerUniqueId) {
+        if (!this.passengers.contains(passengerUniqueId)) {
+            // Riders are ordered first in the Java SET_PASSENGERS packet
+            this.passengers.add(0, passengerUniqueId);
+        }
+    }
+
+    public void removePassenger(final long passengerUniqueId) {
+        this.passengers.remove(passengerUniqueId);
+    }
+
+    public void clearPassengers() {
+        this.passengers.clear();
     }
 
     public List<Long> passengers() {
@@ -245,6 +256,26 @@ public class Entity {
         return this.mountRuntimeId;
     }
 
+    public void clearMountState() {
+        this.mountRuntimeId = -1;
+    }
+
+    /**
+     * Sends the current passenger list of this entity to the Java client.
+     * Passengers that are no longer tracked are dropped from the list first.
+     */
+    public void sendPassengerUpdate() {
+        final EntityTracker entityTracker = this.user.get(EntityTracker.class);
+        this.passengers.removeIf(passengerUid -> entityTracker.getEntityByUid(passengerUid) == null);
+        final PacketWrapper setPassengers = PacketWrapper.create(ClientboundPackets26_1.SET_PASSENGERS, this.user);
+        setPassengers.write(Types.VAR_INT, this.javaId); // vehicle
+        setPassengers.write(Types.VAR_INT, this.passengers.size()); // number of passengers
+        for (long passengerUid : this.passengers) {
+            setPassengers.write(Types.VAR_INT, entityTracker.getEntityByUid(passengerUid).javaId()); // passenger id
+        }
+        setPassengers.send(BedrockProtocol.class);
+    }
+
     public final int getJavaEntityDataIndex(final String fieldName) {
         final int index = BedrockProtocol.MAPPINGS.getJavaEntityDataFields().get(this.javaType).indexOf(fieldName);
         if (index == -1) {
@@ -254,11 +285,7 @@ public class Entity {
     }
 
     protected boolean translateEntityData(final ActorDataIDs id, final EntityData entityData, final List<EntityData> javaEntityData) {
-        if (ViaBedrock.getConfig().shouldEnableExperimentalFeatures()) {
-            return EntityMetadataRewriter.rewrite(user, this, id, entityData, javaEntityData);
-        }
-
-        return false;
+        return EntityMetadataRewriter.rewrite(user, this, id, entityData, javaEntityData);
     }
 
     protected void onEntityDataChanged() {

--- a/src/main/java/net/raphimc/viabedrock/api/util/PacketFactory.java
+++ b/src/main/java/net/raphimc/viabedrock/api/util/PacketFactory.java
@@ -32,7 +32,11 @@ import net.raphimc.viabedrock.protocol.BedrockProtocol;
 import net.raphimc.viabedrock.protocol.ServerboundBedrockPackets;
 import net.raphimc.viabedrock.protocol.data.BedrockMappingData;
 import net.raphimc.viabedrock.protocol.data.enums.bedrock.ContainerType;
+import net.raphimc.viabedrock.protocol.data.enums.bedrock.generated.ActorLinkType;
+import net.raphimc.viabedrock.protocol.data.enums.bedrock.generated.InteractPacketPayload_Action;
+import net.raphimc.viabedrock.protocol.data.enums.bedrock.generated.PlayerActionType;
 import net.raphimc.viabedrock.protocol.data.enums.bedrock.generated.ServerboundLoadingScreenPacketType;
+import net.raphimc.viabedrock.protocol.model.EntityLink;
 import net.raphimc.viabedrock.protocol.data.enums.java.EntityEvent;
 import net.raphimc.viabedrock.protocol.data.enums.java.GameEventType;
 import net.raphimc.viabedrock.protocol.data.enums.java.generated.CustomChatCompletionsAction;
@@ -129,6 +133,30 @@ public class PacketFactory {
         containerClose.write(Types.BYTE, (byte) containerType.getValue()); // type
         containerClose.write(Types.BOOLEAN, false); // server initiated
         containerClose.sendToServer(BedrockProtocol.class);
+    }
+
+    public static void sendBedrockPlayerAction(final UserConnection user, final long entityId, final PlayerActionType actionType, final BlockPosition position, final BlockPosition resultPosition, final int face) {
+        final PacketWrapper playerAction = PacketWrapper.create(ServerboundBedrockPackets.PLAYER_ACTION, user);
+        playerAction.write(BedrockTypes.UNSIGNED_VAR_LONG, entityId); // entity runtime id
+        playerAction.write(BedrockTypes.VAR_INT, actionType.getValue()); // action type
+        playerAction.write(BedrockTypes.BLOCK_POSITION, position); // block position
+        playerAction.write(BedrockTypes.BLOCK_POSITION, resultPosition); // result position
+        playerAction.write(BedrockTypes.VAR_INT, face); // face
+        playerAction.sendToServer(BedrockProtocol.class);
+    }
+
+    public static void sendBedrockDismount(final UserConnection user, final long entityRId, final Position3f position) {
+        final PacketWrapper dismountPacket = PacketWrapper.create(ServerboundBedrockPackets.INTERACT, user);
+        dismountPacket.write(Types.UNSIGNED_BYTE, (short) InteractPacketPayload_Action.StopRiding.getValue()); // action
+        dismountPacket.write(BedrockTypes.UNSIGNED_VAR_LONG, entityRId); // target entity runtime id
+        dismountPacket.write(BedrockTypes.OPTIONAL_POSITION_3F, position); // dismount position
+        dismountPacket.sendToServer(BedrockProtocol.class);
+    }
+
+    public static void sendBedrockMount(final UserConnection user, final Entity vehicle, final Entity passenger) {
+        final PacketWrapper linkPacket = PacketWrapper.create(ServerboundBedrockPackets.SET_ENTITY_LINK, user);
+        linkPacket.write(BedrockTypes.ENTITY_LINK, new EntityLink(vehicle.uniqueId(), passenger.uniqueId(), ActorLinkType.Riding, false, true, 0F)); // passenger initiated link
+        linkPacket.sendToServer(BedrockProtocol.class);
     }
 
     public static void sendBedrockLoadingScreen(final UserConnection user, final ServerboundLoadingScreenPacketType type, final Long loadingScreenId) {

--- a/src/main/java/net/raphimc/viabedrock/experimental/ExperimentalFeatures.java
+++ b/src/main/java/net/raphimc/viabedrock/experimental/ExperimentalFeatures.java
@@ -353,51 +353,7 @@ public class ExperimentalFeatures {
                 }
             }
         });
-        protocol.registerClientbound(ClientboundBedrockPackets.SET_ENTITY_LINK, ClientboundPackets26_1.SET_PASSENGERS, wrapper -> {
-            final EntityTracker entityTracker = wrapper.user().get(EntityTracker.class);
-
-            final EntityLink linkType = wrapper.read(BedrockTypes.ENTITY_LINK);
-            final Entity vehicle = entityTracker.getEntityByUid(linkType.fromEntityUniqueId());
-            if (vehicle == null) {
-                wrapper.cancel();
-                return;
-            }
-
-            final Entity passenger = entityTracker.getEntityByUid(linkType.toEntityUniqueId());
-
-            // TODO: Handle Passenger type if needed
-            switch (linkType.type()) {
-                case Riding, Passenger -> { // TODO: This needs to be ordered properly based on the link types (rider first, then passengers)
-                    vehicle.addPassenger(passenger.uniqueId());
-
-                    wrapper.write(Types.VAR_INT, entityTracker.getEntityByUid(linkType.fromEntityUniqueId()).javaId()); // vehicle
-                    wrapper.write(Types.VAR_INT, vehicle.passengers().size()); // number of passengers
-                    for (long passengerUid : vehicle.passengers()) {
-                        wrapper.write(Types.VAR_INT, entityTracker.getEntityByUid(passengerUid).javaId()); // passenger id
-                    }
-
-                    if (passenger.uniqueId() == entityTracker.getClientPlayer().uniqueId()) { // TODO: This could be applied to all passengers not just players
-                        // The player is now riding an entity, update the state
-                        entityTracker.getClientPlayer().setMountEntityRId(entityTracker.getEntityByUid(linkType.fromEntityUniqueId()).runtimeId());
-                    }
-                }
-                case None -> { // Remove
-                    vehicle.removePassenger(passenger.uniqueId());
-
-                    wrapper.write(Types.VAR_INT, vehicle.javaId()); // vehicle
-                    wrapper.write(Types.VAR_INT, vehicle.passengers().size()); // number of passengers
-                    for (long passengerUid : vehicle.passengers()) {
-                        wrapper.write(Types.VAR_INT, entityTracker.getEntityByUid(passengerUid).javaId()); // passenger id
-                    }
-
-                    if (passenger.uniqueId() == entityTracker.getClientPlayer().uniqueId()) {// TODO: This could be applied to all passengers not just players
-                        // The player is no longer riding an entity, update the state
-                        entityTracker.getClientPlayer().setMountEntityRId(-1);
-                        entityTracker.getClientPlayer().setRequestedDismount(false);
-                    }
-                }
-            }
-        });
+        // SET_ENTITY_LINK handling has been promoted to the stable path (EntityPackets)
 
         protocol.registerClientbound(ClientboundBedrockPackets.MAP_ITEM_DATA, ClientboundPackets26_1.MAP_ITEM_DATA, wrapper -> {
             wrapper.cancel();

--- a/src/main/java/net/raphimc/viabedrock/protocol/model/EntityProperties.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/model/EntityProperties.java
@@ -21,4 +21,13 @@ import com.viaversion.viaversion.libs.fastutil.ints.Int2IntMap;
 import com.viaversion.viaversion.libs.fastutil.ints.Int2ObjectMap;
 
 public record EntityProperties(Int2IntMap intProperties, Int2ObjectMap<Float> floatProperties) {
+
+    /**
+     * Bedrock entity properties (PropertySyncData). The property indexes resolve against the
+     * property definitions of the entity's resource pack definition, which ViaBedrock does not
+     * parse yet, so the values are currently skipped.
+     */
+    public boolean isEmpty() {
+        return this.intProperties.isEmpty() && this.floatProperties.isEmpty();
+    }
 }

--- a/src/main/java/net/raphimc/viabedrock/protocol/packet/ClientPlayerPackets.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/packet/ClientPlayerPackets.java
@@ -19,6 +19,7 @@ package net.raphimc.viabedrock.protocol.packet;
 
 import com.viaversion.viaversion.api.minecraft.BlockPosition;
 import com.viaversion.viaversion.api.minecraft.Vector3d;
+import com.viaversion.viaversion.api.minecraft.entities.EntityTypes26_2;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandler;
 import com.viaversion.viaversion.api.protocol.remapper.PacketHandlers;
@@ -289,12 +290,14 @@ public class ClientPlayerPackets {
                     clientPlayer.addAuthInputData(PlayerAuthInputPacketPayload_InputData.StopSprinting);
                 }
                 case START_FALL_FLYING -> {
-                    if (ViaBedrock.getConfig().shouldEnableExperimentalFeatures()) {
-                        clientPlayer.setGliding(true);
-                        clientPlayer.addAuthInputData(PlayerAuthInputPacketPayload_InputData.StartGliding);
-                    }
+                    clientPlayer.setGliding(true);
+                    clientPlayer.addAuthInputData(PlayerAuthInputPacketPayload_InputData.StartGliding);
                 }
-                default -> throw new IllegalStateException("Unhandled PlayerCommandAction: " + action);
+                // Riding jumps are driven by the Jumping input flag in PlayerAuthInput;
+                // the Bedrock server computes the jump scale from the held ticks itself
+                case START_RIDING_JUMP, STOP_RIDING_JUMP -> {
+                }
+                default -> ViaBedrock.getPlatform().getLogger().log(Level.FINE, "Unhandled PlayerCommandAction: " + action);
             }
         });
         protocol.registerServerbound(ServerboundPackets26_1.PLAYER_ACTION, null, wrapper -> {
@@ -408,6 +411,14 @@ public class ClientPlayerPackets {
                 return;
             }
 
+            // Right-clicking a rideable entity with the main hand mounts it in Java Edition.
+            // Bedrock clients mount by sending a passenger-initiated SetActorLink packet.
+            if (EntityPackets.isRideable(entity)) {
+                wrapper.cancel();
+                PacketFactory.sendBedrockMount(wrapper.user(), entity, entityTracker.getClientPlayer());
+                return;
+            }
+
             // TODO: Bedrock client sends INTERACT packet when hovered entity changes. Might be used by anticheats
 
             wrapper.write(BedrockTypes.VAR_INT, 0); // legacy request id
@@ -457,7 +468,8 @@ public class ClientPlayerPackets {
             clientPlayer.setInputFlags(inputFlags);
         });
         protocol.registerServerbound(ServerboundPackets26_1.CLIENT_TICK_END, ServerboundBedrockPackets.PLAYER_AUTH_INPUT, wrapper -> {
-            final ClientPlayerEntity clientPlayer = wrapper.user().get(EntityTracker.class).getClientPlayer();
+            final EntityTracker entityTracker = wrapper.user().get(EntityTracker.class);
+            final ClientPlayerEntity clientPlayer = entityTracker.getClientPlayer();
             final Position3f prevPosition = clientPlayer.prevPosition();
             final boolean prevOnGround = clientPlayer.prevOnGround();
             final Set<InputFlag> prevInputFlags = clientPlayer.prevInputFlags();
@@ -548,6 +560,23 @@ public class ClientPlayerPackets {
                 velocity = new Position3f(dx * 0.91F, dy * 0.98F, dz * 0.91F);
             }
 
+            // Client predicted vehicle: while riding, position/velocity are interpreted as the vehicle's.
+            // The input flags must be added before they get serialized below
+            final Entity vehicle = clientPlayer.mountEntityRId() != -1 ? entityTracker.getEntityByRid(clientPlayer.mountEntityRId()) : null;
+            if (vehicle != null) {
+                clientPlayer.addAuthInputData(PlayerAuthInputPacketPayload_InputData.IsInClientPredictedVehicle);
+
+                // Paddle force mode: the oar states are implied from the movement input
+                if (vehicle.javaType().isOrHasParent(EntityTypes26_2.ABSTRACT_BOAT)) {
+                    if (clientPlayer.inputFlags().contains(InputFlag.JUMP) || clientPlayer.inputFlags().contains(InputFlag.LEFT) || clientPlayer.inputFlags().contains(InputFlag.FORWARD)) {
+                        clientPlayer.addAuthInputData(PlayerAuthInputPacketPayload_InputData.PaddlingLeft);
+                    }
+                    if (clientPlayer.inputFlags().contains(InputFlag.JUMP) || clientPlayer.inputFlags().contains(InputFlag.RIGHT) || clientPlayer.inputFlags().contains(InputFlag.FORWARD)) {
+                        clientPlayer.addAuthInputData(PlayerAuthInputPacketPayload_InputData.PaddlingRight);
+                    }
+                }
+            }
+
             wrapper.write(BedrockTypes.FLOAT_LE, clientPlayer.rotation().x()); // pitch
             wrapper.write(BedrockTypes.FLOAT_LE, clientPlayer.rotation().y()); // yaw
             wrapper.write(BedrockTypes.POSITION_3F, clientPlayer.position()); // position
@@ -582,10 +611,21 @@ public class ClientPlayerPackets {
                     wrapper.write(BedrockTypes.VAR_INT, blockAction.direction()); // facing
                 }
             }
+            // Client predicted vehicle: while riding, position/velocity are interpreted as the vehicle's
             wrapper.write(Types.BOOLEAN, true); // vehicle rotation optional reflected
-            wrapper.write(Types.BOOLEAN, false); // not in predicted vehicle
+            if (vehicle != null) {
+                wrapper.write(Types.BOOLEAN, true); // vehicle rotation present
+                wrapper.write(BedrockTypes.POSITION_2F, new Position2f(0F, clientPlayer.rotation().y())); // vehicle rotation (pitch, yaw)
+            } else {
+                wrapper.write(Types.BOOLEAN, false); // no vehicle rotation
+            }
             wrapper.write(Types.BOOLEAN, true); // predicted vehicle id optional reflected
-            wrapper.write(Types.BOOLEAN, false); // not in predicted vehicle
+            if (vehicle != null) {
+                wrapper.write(Types.BOOLEAN, true); // predicted vehicle id present
+                wrapper.write(BedrockTypes.VAR_LONG, vehicle.uniqueId()); // client predicted vehicle
+            } else {
+                wrapper.write(Types.BOOLEAN, false); // not in predicted vehicle
+            }
             wrapper.write(BedrockTypes.POSITION_2F, new Position2f(0F, 0F)); // analog move vector
             wrapper.write(BedrockTypes.POSITION_3F, MathUtil.calculateCameraOrientation(clientPlayer.rotation().y(), clientPlayer.rotation().x())); // camera orientation
             wrapper.write(BedrockTypes.POSITION_2F, MathUtil.calculateMovementDirections(clientPlayer.authInputData(), false)); // raw move vector

--- a/src/main/java/net/raphimc/viabedrock/protocol/packet/EntityPackets.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/packet/EntityPackets.java
@@ -19,6 +19,7 @@ package net.raphimc.viabedrock.protocol.packet;
 
 import com.google.common.collect.Lists;
 import com.viaversion.nbt.tag.CompoundTag;
+import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.Holder;
 import com.viaversion.viaversion.api.minecraft.PaintingVariant;
 import com.viaversion.viaversion.api.minecraft.Vector3d;
@@ -131,7 +132,15 @@ public class EntityPackets {
             if (entity instanceof LivingEntity livingEntity) {
                 livingEntity.updateAttributes(attributes);
             }
+            if (!entityProperties.isEmpty()) {
+                ViaBedrock.getPlatform().getLogger().log(Level.FINE, "Skipping " + entityProperties.intProperties().size() + " int and " + entityProperties.floatProperties().size() + " float entity properties for entity " + entity.type());
+            }
             entity.updateEntityData(entityData);
+
+            // Apply initial entity links (e.g. passengers riding on this entity)
+            for (EntityLink entityLink : entityLinks) {
+                handleEntityLink(wrapper.user(), entityLink);
+            }
         });
         protocol.registerClientbound(ClientboundBedrockPackets.ADD_ITEM_ENTITY, ClientboundPackets26_1.ADD_ENTITY, wrapper -> {
             final EntityTracker entityTracker = wrapper.user().get(EntityTracker.class);
@@ -505,10 +514,20 @@ public class EntityPackets {
                 return;
             }
 
+            if (!entityProperties.isEmpty()) {
+                ViaBedrock.getPlatform().getLogger().log(Level.FINE, "Skipping " + entityProperties.intProperties().size() + " int and " + entityProperties.floatProperties().size() + " float entity properties for entity " + entity.type());
+            }
+
             final List<EntityData> javaEntityData = new ArrayList<>();
             entity.updateEntityData(entityData, javaEntityData);
             wrapper.write(Types.VAR_INT, entity.javaId()); // entity id
             wrapper.write(VersionedTypes.V26_2.entityDataList, javaEntityData); // entity data
+        });
+        protocol.registerClientbound(ClientboundBedrockPackets.SET_ENTITY_LINK, ClientboundPackets26_1.SET_PASSENGERS, wrapper -> {
+            wrapper.cancel();
+
+            final EntityLink entityLink = wrapper.read(BedrockTypes.ENTITY_LINK); // entity link
+            handleEntityLink(wrapper.user(), entityLink);
         });
         protocol.registerClientbound(ClientboundBedrockPackets.MOB_EFFECT, ClientboundPackets26_1.UPDATE_MOB_EFFECT, wrapper -> {
             final long entityRuntimeId = wrapper.read(BedrockTypes.UNSIGNED_VAR_LONG); // entity runtime id
@@ -638,6 +657,57 @@ public class EntityPackets {
             wrapper.write(Types.VAR_INT, collectorEntity.javaId()); // collector entity id
             wrapper.write(Types.VAR_INT, 0); // amount
         });
+    }
+
+    /**
+     * Heuristic check for entities that can be mounted by right-clicking them in Java Edition.
+     * The Java server normally decides rideability; this approximation covers all vanilla rideables
+     * and lets the Bedrock server reject invalid mount requests.
+     */
+    public static boolean isRideable(final Entity entity) {
+        final EntityTypes26_2 type = entity.javaType();
+        return type.isOrHasParent(EntityTypes26_2.ABSTRACT_BOAT)
+                || type.isOrHasParent(EntityTypes26_2.ABSTRACT_HORSE)
+                || type.isOrHasParent(EntityTypes26_2.ABSTRACT_MINECART)
+                || type == EntityTypes26_2.CAMEL
+                || type == EntityTypes26_2.CAMEL_HUSK
+                || type == EntityTypes26_2.STRIDER
+                || type == EntityTypes26_2.PIG
+                || type == EntityTypes26_2.HAPPY_GHAST;
+    }
+
+    /**
+     * Applies a Bedrock entity link (mount state change) to the tracked entities and
+     * notifies the Java client with an updated SET_PASSENGERS packet for the vehicle.
+     */    public static void handleEntityLink(final UserConnection user, final EntityLink entityLink) {
+        final EntityTracker entityTracker = user.get(EntityTracker.class);
+        final Entity vehicle = entityTracker.getEntityByUid(entityLink.fromEntityUniqueId());
+        final Entity passenger = entityTracker.getEntityByUid(entityLink.toEntityUniqueId());
+        if (vehicle == null || passenger == null) {
+            ViaBedrock.getPlatform().getLogger().log(Level.FINE, "Skipping entity link for untracked entities: " + entityLink);
+            return;
+        }
+
+        switch (entityLink.type()) {
+            case Riding -> { // Rider, ordered first in the Java SET_PASSENGERS packet
+                vehicle.addRider(passenger.uniqueId());
+                passenger.setMountEntityRId(vehicle.runtimeId());
+                vehicle.sendPassengerUpdate();
+            }
+            case Passenger -> {
+                vehicle.addPassenger(passenger.uniqueId());
+                passenger.setMountEntityRId(vehicle.runtimeId());
+                vehicle.sendPassengerUpdate();
+            }
+            case None -> { // Dismount
+                vehicle.removePassenger(passenger.uniqueId());
+                passenger.clearMountState();
+                if (passenger instanceof ClientPlayerEntity clientPlayer) {
+                    clientPlayer.setRequestedDismount(false);
+                }
+                vehicle.sendPassengerUpdate();
+            }
+        }
     }
 
 }

--- a/src/main/java/net/raphimc/viabedrock/protocol/packet/OtherPlayerPackets.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/packet/OtherPlayerPackets.java
@@ -47,6 +47,8 @@ import net.raphimc.viabedrock.protocol.rewriter.GameTypeRewriter;
 import net.raphimc.viabedrock.protocol.rewriter.ItemRewriter;
 import net.raphimc.viabedrock.protocol.storage.EntityTracker;
 import net.raphimc.viabedrock.protocol.storage.GameSessionStorage;
+
+import java.util.logging.Level;
 import net.raphimc.viabedrock.protocol.types.BedrockTypes;
 
 import java.util.UUID;
@@ -113,7 +115,15 @@ public class OtherPlayerPackets {
             setEquipment.send(BedrockProtocol.class);
 
             entity.sendInitialEntityData();
+            if (!entityProperties.isEmpty()) {
+                ViaBedrock.getPlatform().getLogger().log(Level.FINE, "Skipping " + entityProperties.intProperties().size() + " int and " + entityProperties.floatProperties().size() + " float entity properties for player " + username);
+            }
             entity.updateEntityData(entityData);
+
+            // Apply initial entity links (e.g. this player riding on an entity)
+            for (EntityLink entityLink : entityLinks) {
+                EntityPackets.handleEntityLink(wrapper.user(), entityLink);
+            }
         });
         protocol.registerClientbound(ClientboundBedrockPackets.MOVE_PLAYER, ClientboundPackets26_1.ENTITY_POSITION_SYNC, wrapper -> {
             final EntityTracker entityTracker = wrapper.user().get(EntityTracker.class);

--- a/src/main/java/net/raphimc/viabedrock/protocol/rewriter/EntityMetadataRewriter.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/rewriter/EntityMetadataRewriter.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package net.raphimc.viabedrock.experimental.rewriter;
+package net.raphimc.viabedrock.protocol.rewriter;
 
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.EulerAngle;
@@ -24,6 +24,7 @@ import com.viaversion.viaversion.api.minecraft.entitydata.EntityData;
 import com.viaversion.viaversion.api.type.types.version.VersionedTypes;
 import net.raphimc.viabedrock.ViaBedrock;
 import net.raphimc.viabedrock.api.model.entity.Entity;
+import net.raphimc.viabedrock.api.util.TextUtil;
 import net.raphimc.viabedrock.protocol.data.enums.bedrock.ActorDataIDs;
 import net.raphimc.viabedrock.protocol.data.enums.bedrock.ActorFlags;
 import net.raphimc.viabedrock.protocol.data.generated.java.EntityDataFields;
@@ -36,7 +37,7 @@ import java.util.logging.Level;
 
 public class EntityMetadataRewriter {
 
-    // Called in Entity#translateEntityData if experimental features are enabled
+    // Called in Entity#translateEntityData
     public static boolean rewrite(final UserConnection user, final Entity entity, final ActorDataIDs id, final EntityData entityData, final List<EntityData> javaEntityData) {
         EntityTracker entityTracker = user.get(EntityTracker.class);
 
@@ -110,9 +111,14 @@ public class EntityMetadataRewriter {
                 }
 
                 if (entity.javaType().is(EntityTypes26_2.SHEEP)) {
+                    // Combine sheared flag with the current wool color (Java stores both in one byte)
                     byte sheepBitMask = 0;
                     if (bedrockFlags.contains(ActorFlags.SHEARED)) {
                         sheepBitMask |= 0x10;
+                    }
+                    final EntityData storedColor = entity.entityData().get(ActorDataIDs.COLOR_INDEX);
+                    if (storedColor != null) {
+                        sheepBitMask |= (byte) (readNumber(storedColor).intValue() & 0x0F); // Lower 4 bits for color
                     }
                     javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.WOOL), VersionedTypes.V26_2.entityDataTypes().byteType, sheepBitMask));
                 }
@@ -304,9 +310,12 @@ public class EntityMetadataRewriter {
                     case WOLF, CAT -> {
                         javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.COLLAR_COLOR), VersionedTypes.V26_2.entityDataTypes().varIntType, javaColorIndex));
                     }
-                    case SHEEP -> { // TODO: This seems to get overwritten by the entity flags sheared value, need to combine both
-                        byte sheepBitMask = 0;
-                        sheepBitMask |= (byte) (javaColorIndex & 0x0F); // Lower 4 bits for color
+                    case SHEEP -> {
+                        // Combine wool color with the current sheared flag (Java stores both in one byte)
+                        byte sheepBitMask = (byte) (javaColorIndex & 0x0F); // Lower 4 bits for color
+                        if (entity.entityFlags().contains(ActorFlags.SHEARED)) {
+                            sheepBitMask |= 0x10;
+                        }
                         javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.WOOL), VersionedTypes.V26_2.entityDataTypes().byteType, sheepBitMask));
                     }
                     default -> {
@@ -554,7 +563,7 @@ public class EntityMetadataRewriter {
             }
             case DATA_WAITING -> {
                 if (entity.javaType().is(EntityTypes26_2.AREA_EFFECT_CLOUD)) {
-                    boolean isWaiting = (boolean) entityData.getValue();
+                    boolean isWaiting = readNumber(entityData).intValue() != 0;
                     javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.WAITING), VersionedTypes.V26_2.entityDataTypes().booleanType, isWaiting));
                 } else {
                     ViaBedrock.getPlatform().getLogger().log(Level.WARNING, "Received DATA_WAITING for non-AREA_EFFECT_CLOUD entity " + entity.type());
@@ -637,6 +646,38 @@ public class EntityMetadataRewriter {
                     javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.ATTACK_TARGET), VersionedTypes.V26_2.entityDataTypes().varIntType, targetEntity.javaId()));
                 } else if (targetId != 0)  {
                     ViaBedrock.getPlatform().getLogger().log(Level.WARNING, "Received TARGET for non-GUARDIAN entity " + entity.type() + " with non-zero value " + targetId);
+                }
+            }
+            case NAME -> {
+                // Custom name tags, e.g. from name tags or renamed entities. An empty name clears the custom name
+                if (entityData.getValue() instanceof String name) {
+                    javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.CUSTOM_NAME), VersionedTypes.V26_2.entityDataTypes().optionalComponentType, name.isEmpty() ? null : TextUtil.textComponentToNbt(TextUtil.stringToTextComponent(name))));
+                }
+            }
+            case NAMETAG_ALWAYS_SHOW -> {
+                // Whether the nametag is always visible (Java: only if a custom name is set)
+                javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.CUSTOM_NAME_VISIBLE), VersionedTypes.V26_2.entityDataTypes().booleanType, readNumber(entityData).intValue() != 0));
+            }
+            case HURT -> {
+                // Bedrock sends the taken damage as long as the entity flashes red, Java stores the remaining red flash ticks
+                if (entity.javaType().isOrHasParent(EntityTypes26_2.LIVING_ENTITY)) {
+                    final int hurtTicks = readNumber(entityData).intValue() > 0 ? 10 : 0;
+                    javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.HURT), VersionedTypes.V26_2.entityDataTypes().varIntType, hurtTicks));
+                }
+            }
+            case HURT_DIR -> {
+                if (entity.javaType().isOrHasParent(EntityTypes26_2.LIVING_ENTITY)) {
+                    javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.HURTDIR), VersionedTypes.V26_2.entityDataTypes().floatType, readNumber(entityData).floatValue()));
+                }
+            }
+            case EFFECT_COLOR -> {
+                if (entity.javaType().isOrHasParent(EntityTypes26_2.LIVING_ENTITY)) {
+                    javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.EFFECT_COLOR), VersionedTypes.V26_2.entityDataTypes().varIntType, readNumber(entityData).intValue()));
+                }
+            }
+            case USING_ITEM -> {
+                if (entity.javaType().isOrHasParent(EntityTypes26_2.LIVING_ENTITY)) {
+                    javaEntityData.add(new EntityData(entity.getJavaEntityDataIndex(EntityDataFields.USING_ITEM), VersionedTypes.V26_2.entityDataTypes().booleanType, readNumber(entityData).intValue() != 0));
                 }
             }
             case AGENT, BALLOON_ANCHOR -> {} // Education edition only, ignore

--- a/src/main/java/net/raphimc/viabedrock/protocol/storage/EntityTracker.java
+++ b/src/main/java/net/raphimc/viabedrock/protocol/storage/EntityTracker.java
@@ -38,6 +38,7 @@ import net.raphimc.viabedrock.api.model.entity.*;
 import net.raphimc.viabedrock.protocol.BedrockProtocol;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -106,6 +107,23 @@ public class EntityTracker extends StoredObject {
             throw new IllegalArgumentException("Cannot remove client player entity");
         }
 
+        // Clean up mount state: detach this entity from its vehicle and its own passengers
+        if (entity.mountEntityRId() != -1) {
+            final Entity vehicle = this.getEntityByRid(entity.mountEntityRId());
+            if (vehicle != null) {
+                vehicle.removePassenger(entity.uniqueId());
+                vehicle.sendPassengerUpdate();
+            }
+            entity.clearMountState();
+        }
+        for (long passengerUid : entity.passengers()) {
+            final Entity passenger = this.getEntityByUid(passengerUid);
+            if (passenger != null) {
+                passenger.clearMountState();
+            }
+        }
+        entity.clearPassengers();
+
         this.entities.remove(entity.uniqueId());
         this.runtimeIdToUniqueId.remove(entity.runtimeId());
         this.javaIdToUniqueId.remove(entity.javaId());
@@ -166,17 +184,28 @@ public class EntityTracker extends StoredObject {
     }
 
     public void prepareForRespawn() {
-        for (Entity entity : this.entities.values()) {
+        // The client player entity persists across respawn: reset its mount state, since
+        // the vehicles it was riding on are about to be removed
+        if (this.clientPlayerEntity != null) {
+            this.clientPlayerEntity.clearMountState();
+            this.clientPlayerEntity.clearPassengers();
+        }
+        for (Iterator<Entity> iterator = this.entities.values().iterator(); iterator.hasNext(); ) {
+            final Entity entity = iterator.next();
+            if (entity == this.clientPlayerEntity) {
+                continue;
+            }
+            iterator.remove();
+            this.runtimeIdToUniqueId.remove(entity.runtimeId());
+            this.javaIdToUniqueId.remove(entity.javaId());
             entity.remove();
         }
+        this.itemFrames.clear();
     }
 
     public Entity getEntityByRid(final long runtimeId) {
-        Long uniqueId = this.runtimeIdToUniqueId.get(runtimeId);
-        if (uniqueId == null) {
-            return null;
-        }
-        return this.entities.get(uniqueId.longValue());
+        final Long uniqueId = this.runtimeIdToUniqueId.get(runtimeId);
+        return uniqueId != null ? this.entities.get(uniqueId.longValue()) : null;
     }
 
     public Entity getEntityByUid(final long uniqueId) {
@@ -184,7 +213,8 @@ public class EntityTracker extends StoredObject {
     }
 
     public Entity getEntityByJid(final int javaId) {
-        return this.entities.get((long) this.javaIdToUniqueId.get(javaId));
+        final Long uniqueId = this.javaIdToUniqueId.get(javaId);
+        return uniqueId != null ? this.entities.get(uniqueId.longValue()) : null;
     }
 
     public ClientPlayerEntity getClientPlayer() {


### PR DESCRIPTION
## Summary

Promotes entity metadata translation and entity mounting from experimental to the stable protocol.

### Entity metadata
- Un-gated `EntityMetadataRewriter` (moved to `protocol.rewriter`): translates for all connections, not just experimental mode
- New translations: `NAME` -> `CUSTOM_NAME`, `NAMETAG_ALWAYS_SHOW` -> `CUSTOM_NAME_VISIBLE`, `HURT`/`HURT_DIR`, `EFFECT_COLOR`, `USING_ITEM`
- Fixed the sheep wool color/sheared flag overwrite (combined bitmask, order-independent)
- `EntityProperties` (PropertySyncData) intentionally skipped with FINE logging (needs resource pack property parsing)

### Entity mounting
- Stable `SET_ENTITY_LINK` -> `SET_PASSENGERS` handling with rider-first ordering and mount state for all passengers
- Spawn link replay in `ADD_ENTITY`/`ADD_PLAYER`, entity removal/respawn cleanup, null-safe entity lookups
- Serverbound: passenger-initiated `SetActorLink` mount on `INTERACT`, sneak dismount via `Interact.StopRiding` with position
- `PLAYER_AUTH_INPUT` carries `IsInClientPredictedVehicle` + vehicle rotation + predicted vehicle id; boat paddling flags from movement input; riding jumps are no-ops (jump scale computed by the server)
- Removed the experimental `SET_ENTITY_LINK` registration and the dead `ExperimentalPacketFactory`

Verified with `./gradlew build` (BUILD SUCCESSFUL).